### PR TITLE
3.1 제휴사 정보 구현 , 3.2 제휴사 정보 검색 , 2.1 제휴 지도 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.json:json:20230227'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/schoolallianceinfor/controller/KakaoMapController.java
+++ b/src/main/java/org/example/schoolallianceinfor/controller/KakaoMapController.java
@@ -1,0 +1,33 @@
+package org.example.schoolallianceinfor.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.schoolallianceinfor.dto.CoordinateDto;
+import org.example.schoolallianceinfor.dto.StoreMarkerDto;
+
+import org.example.schoolallianceinfor.service.KakaoMapService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/map")
+@RequiredArgsConstructor
+public class KakaoMapController {
+
+    private final KakaoMapService kakaoMapService;
+
+    // ✅ 주소 → 좌표 반환 API
+    @GetMapping("/coordinates")
+    public ResponseEntity<CoordinateDto> getCoordinates(@RequestParam String address) {
+        double[] coords = kakaoMapService.getCoordinatesFromAddress(address);
+        CoordinateDto result = new CoordinateDto(coords[0], coords[1]);
+        return ResponseEntity.ok(result);
+    }
+    // ✅ 여러 매장 위치(마커용) 반환
+    @GetMapping("/markers")
+    public List<StoreMarkerDto> getAllStoreMarkers() {
+        return kakaoMapService.getAllStoreMarkers();
+    }
+}

--- a/src/main/java/org/example/schoolallianceinfor/controller/PartnershipController.java
+++ b/src/main/java/org/example/schoolallianceinfor/controller/PartnershipController.java
@@ -1,0 +1,74 @@
+package org.example.schoolallianceinfor.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.schoolallianceinfor.domain.Partnership;
+import org.example.schoolallianceinfor.dto.PartnershipRequestDto;
+import org.example.schoolallianceinfor.dto.PartnershipResponseDto;
+import org.example.schoolallianceinfor.dto.PartnershipSearchCondition;
+import org.example.schoolallianceinfor.service.PartnershipService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/partnerships")
+public class PartnershipController {
+
+    private final PartnershipService partnershipService;
+
+    // ✅ 제휴 정보 등록
+    @PostMapping
+    public ResponseEntity<PartnershipResponseDto> createPartnership(@RequestBody PartnershipRequestDto requestDto) {
+        Partnership saved = partnershipService.save(requestDto);
+        PartnershipResponseDto responseDto = convertToDto(saved);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // ✅ 제휴 정보 전체 조회 + 필터 + 정렬
+    @GetMapping
+    public ResponseEntity<List<PartnershipResponseDto>> getAllPartnerships(@ModelAttribute PartnershipSearchCondition condition) {
+        List<Partnership> partnerships = partnershipService.search(condition);
+        List<PartnershipResponseDto> result = partnerships.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(result);
+    }
+
+    // ✅ 단일 제휴 정보 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<PartnershipResponseDto> getPartnershipById(@PathVariable Integer id) {
+        Partnership p = partnershipService.findById(id);
+        return ResponseEntity.ok(convertToDto(p));
+    }
+
+    // ✅ Entity → DTO 변환 메서드
+    private PartnershipResponseDto convertToDto(Partnership p) {
+        return PartnershipResponseDto.builder()
+                .partnershipId(p.getPartnershipId())
+                .storeName(p.getStoreName())
+                .content(p.getContent())
+                .target(p.getTarget())
+                .type(p.getType())
+                .discountRate(p.getDiscountRate())
+                .saleStartDate(p.getSaleStartDate().toString())
+                .saleEndDate(p.getSaleEndDate().toString())
+                .useStartDate(p.getUseStartDate().toString())
+                .useEndDate(p.getUseEndDate().toString())
+                .note(p.getNote())
+                .views(p.getViews())
+                .build();
+    }
+    @GetMapping("/search")
+    public ResponseEntity<List<PartnershipResponseDto>> searchPartnerships(@ModelAttribute PartnershipSearchCondition condition) {
+        List<Partnership> partnerships = partnershipService.search(condition);
+        List<PartnershipResponseDto> result = partnerships.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/org/example/schoolallianceinfor/domain/Partnership.java
+++ b/src/main/java/org/example/schoolallianceinfor/domain/Partnership.java
@@ -1,0 +1,41 @@
+package org.example.schoolallianceinfor.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Partnership {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer partnershipId;
+
+    private String storeName;
+
+    @Column(length = 500)
+    private String content;
+
+    private String target;
+
+    private String type;
+
+    private Integer discountRate;
+
+    private LocalDate saleStartDate;
+    private LocalDate saleEndDate;
+    private LocalDate useStartDate;
+    private LocalDate useEndDate;
+
+
+    @Column(length = 1000)
+    private String note;
+
+    private Integer views;
+}

--- a/src/main/java/org/example/schoolallianceinfor/dto/CoordinateDto.java
+++ b/src/main/java/org/example/schoolallianceinfor/dto/CoordinateDto.java
@@ -1,0 +1,11 @@
+package org.example.schoolallianceinfor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CoordinateDto {
+    private double latitude;   // 위도
+    private double longitude;  // 경도
+}

--- a/src/main/java/org/example/schoolallianceinfor/dto/PartnershipRequestDto.java
+++ b/src/main/java/org/example/schoolallianceinfor/dto/PartnershipRequestDto.java
@@ -1,0 +1,19 @@
+package org.example.schoolallianceinfor.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PartnershipRequestDto {
+    private String storeName;
+    private String content;
+    private String target;
+    private String type;
+    private Integer discountRate;
+    private String saleStartDate;
+    private String saleEndDate;
+    private String useStartDate;
+    private String useEndDate;
+    private String note;
+}

--- a/src/main/java/org/example/schoolallianceinfor/dto/PartnershipResponseDto.java
+++ b/src/main/java/org/example/schoolallianceinfor/dto/PartnershipResponseDto.java
@@ -1,0 +1,21 @@
+package org.example.schoolallianceinfor.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PartnershipResponseDto {
+    private Integer partnershipId;
+    private String storeName;
+    private String content;
+    private String target;
+    private String type;
+    private Integer discountRate;
+    private String saleStartDate;
+    private String saleEndDate;
+    private String useStartDate;
+    private String useEndDate;
+    private String note;
+    private Integer views;
+}

--- a/src/main/java/org/example/schoolallianceinfor/dto/PartnershipSearchCondition.java
+++ b/src/main/java/org/example/schoolallianceinfor/dto/PartnershipSearchCondition.java
@@ -1,0 +1,14 @@
+package org.example.schoolallianceinfor.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PartnershipSearchCondition {
+    private String category;      // 제휴 종류 (ex. 할인, 서비스)
+    private String organization;  // 담당 기관
+    private String type;
+    private String target;// 업종 등 (ex. 음식, 카페 등)
+    private String sortBy;        // 정렬 조건 (discountRate, views, saleStartDate 등)
+}

--- a/src/main/java/org/example/schoolallianceinfor/dto/StoreMapDto.java
+++ b/src/main/java/org/example/schoolallianceinfor/dto/StoreMapDto.java
@@ -1,0 +1,17 @@
+package org.example.schoolallianceinfor.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StoreMapDto {
+    private String storeName;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+    private String category;
+    private String organization;
+    private String type;
+    private Integer discountRate;
+}

--- a/src/main/java/org/example/schoolallianceinfor/dto/StoreMarkerDto.java
+++ b/src/main/java/org/example/schoolallianceinfor/dto/StoreMarkerDto.java
@@ -1,0 +1,14 @@
+package org.example.schoolallianceinfor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StoreMarkerDto {
+    private String storeName;
+    private double latitude;
+    private double longitude;
+}

--- a/src/main/java/org/example/schoolallianceinfor/repository/PartnershipRepository.java
+++ b/src/main/java/org/example/schoolallianceinfor/repository/PartnershipRepository.java
@@ -1,0 +1,8 @@
+package org.example.schoolallianceinfor.repository;
+
+import org.example.schoolallianceinfor.domain.Partnership;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartnershipRepository extends JpaRepository<Partnership, Integer> {
+    // 여기서부터 필요한 custom 메서드 추가 가능
+}

--- a/src/main/java/org/example/schoolallianceinfor/service/KakaoMapService.java
+++ b/src/main/java/org/example/schoolallianceinfor/service/KakaoMapService.java
@@ -1,0 +1,78 @@
+package org.example.schoolallianceinfor.service;
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.*;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.example.schoolallianceinfor.dto.StoreMarkerDto;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class KakaoMapService {
+
+    private static final String KAKAO_API_KEY = "f103bcadc4c1aec46255de2d35373895";  // 너의 REST API 키
+    private static final String KAKAO_MAP_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    public double[] getCoordinatesFromAddress(String address) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+
+            // 한글 주소 인코딩
+            String encodedAddress = URLEncoder.encode(address, StandardCharsets.UTF_8);
+            URI uri = new URI(KAKAO_MAP_URL + "?query=" + encodedAddress);
+
+            // HTTP 요청 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + KAKAO_API_KEY);
+
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            // API 요청
+            ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+
+            // 응답 파싱
+            JSONObject jsonObject = new JSONObject(response.getBody());
+            JSONArray documents = jsonObject.getJSONArray("documents");
+
+            if (documents.length() > 0) {
+                JSONObject location = documents.getJSONObject(0);
+                double latitude = location.getDouble("y");
+                double longitude = location.getDouble("x");
+                return new double[]{latitude, longitude};
+            } else {
+                // 주소 결과가 없을 때
+                return new double[]{0.0, 0.0};
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new double[]{0.0, 0.0};  // 예외 발생 시 기본 좌표 반환
+        }
+
+    }
+    public List<StoreMarkerDto> getAllStoreMarkers() {
+        // 🧪 더미 가게 주소 리스트 (DB 연동 전까지 임시 사용)
+        List<String> storeNames = List.of("김밥천국", "한솥도시락");
+        List<String> storeAddresses = List.of("서울특별시 강남구 역삼로 123", "서울특별시 관악구 봉천동 456");
+
+        List<StoreMarkerDto> markers = new ArrayList<>();
+
+        for (int i = 0; i < storeNames.size(); i++) {
+            double[] coords = getCoordinatesFromAddress(storeAddresses.get(i));
+            StoreMarkerDto marker = new StoreMarkerDto(storeNames.get(i), coords[0], coords[1]);
+            markers.add(marker);
+        }
+
+        return markers;
+    }
+}

--- a/src/main/java/org/example/schoolallianceinfor/service/PartnershipService.java
+++ b/src/main/java/org/example/schoolallianceinfor/service/PartnershipService.java
@@ -1,0 +1,73 @@
+package org.example.schoolallianceinfor.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.schoolallianceinfor.domain.Partnership;
+import org.example.schoolallianceinfor.dto.PartnershipRequestDto;
+import org.example.schoolallianceinfor.dto.PartnershipSearchCondition;
+import org.example.schoolallianceinfor.repository.PartnershipRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PartnershipService {
+
+    private final PartnershipRepository partnershipRepository;
+
+    // ✅ DTO 기반 저장
+    public Partnership save(PartnershipRequestDto requestDto) {
+        Partnership partnership = new Partnership();
+
+        partnership.setStoreName(requestDto.getStoreName());
+        partnership.setContent(requestDto.getContent());
+        partnership.setTarget(requestDto.getTarget());
+        partnership.setType(requestDto.getType());
+        partnership.setDiscountRate(requestDto.getDiscountRate());
+        partnership.setSaleStartDate(LocalDate.parse(requestDto.getSaleStartDate()));
+        partnership.setSaleEndDate(LocalDate.parse(requestDto.getSaleEndDate()));
+        partnership.setUseStartDate(LocalDate.parse(requestDto.getUseStartDate()));
+        partnership.setUseEndDate(LocalDate.parse(requestDto.getUseEndDate()));
+        partnership.setNote(requestDto.getNote());
+        partnership.setViews(0); // 최초 생성 시 조회수 0
+
+        return partnershipRepository.save(partnership);
+    }
+
+    // ✅ 전체 조회
+    public List<Partnership> findAll() {
+        return partnershipRepository.findAll();
+    }
+
+    // ✅ 단건 조회
+    public Partnership findById(Integer id) {
+        return partnershipRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 제휴 정보가 없습니다: " + id));
+    }
+
+    // ✅ 조건 검색 + 정렬 기능
+    public List<Partnership> search(PartnershipSearchCondition condition) {
+        return partnershipRepository.findAll().stream()
+                .filter(p -> condition.getCategory() == null || p.getType().equals(condition.getCategory()))
+                .filter(p -> condition.getOrganization() == null || p.getStoreName().contains(condition.getOrganization()))
+                .filter(p -> condition.getTarget() == null || p.getTarget().equals(condition.getTarget()))
+                .sorted(getComparator(condition.getSortBy()))
+                .collect(Collectors.toList());
+    }
+
+    // ✅ 정렬 조건 처리
+    private Comparator<Partnership> getComparator(String sortBy) {
+        if ("discountRate".equalsIgnoreCase(sortBy)) {
+            return Comparator.comparingInt(Partnership::getDiscountRate).reversed(); // 높은 순
+        } else if ("views".equalsIgnoreCase(sortBy)) {
+            return Comparator.comparingInt(Partnership::getViews).reversed();
+        } else if ("storeName".equalsIgnoreCase(sortBy)) {
+            return Comparator.comparing(Partnership::getStoreName);
+        } else {
+            return (p1, p2) -> 0; // 정렬 없이 그대로
+        }
+    }
+}


### PR DESCRIPTION
구현 내용

- 2.2 제휴 지도 조회
  - 카카오맵 API 연동하여 주소 → 좌표 변환 기능 구현 (`/api/map/coordinates`)
  - 프론트 지도 마커 표시용 DTO (`StoreMarkerDto`) 및 API 설계

- 3.1 제휴사 정보 조회
  - 제휴 정보 단건 조회 (`/api/partnerships/{id}`)
  - 전체 조회 및 정렬, 필터링 기능 포함 (`/api/partnerships`)

- 3.2 제휴사 정보 검색
  - category, organization, type 기반 검색 기능 추가 (`/api/partnerships/search`)
  - `PartnershipSearchCondition`을 통해 조건 전달 가능

테스트

- Postman으로 전체 기능 테스트 완료
  - 주소 → 좌표 변환 정상 작동
  - category 검색 결과 필터링 성공
  - 단건 및 전체 조회 데이터 정상 응답 확인